### PR TITLE
Henting av vedlegg 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
-  nais: navikt/nais-deployment@1.1.0
-  slack: circleci/slack@3.3.0
+  nais: 'navikt/nais-deployment@1.1.0'
 
 executors:
   nais-deployer:
@@ -15,23 +14,14 @@ jobs:
     docker:
       - image: circleci/openjdk:11-jdk
     steps:
-      - run:
-          name: Add github to known hosts
-          command: |
-            mkdir ~/.ssh
-            echo "github.com,140.82.118.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
-      - add_ssh_keys:
-          fingerprints:
-            - "b4:dc:80:59:90:f6:6f:02:f1:d0:74:e9:83:dc:a1:80"
       - checkout
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           name: Generate version number and docker image tags
           command: |
-            export VERSION="$(mvn help:evaluate -Dchangelist= -Dexpression=project.version -q -DforceStdout)-$CIRCLE_SHA1"
-            echo $VERSION
-            echo "export VERSION=$VERSION" >> properties.env
+            export VERSION="$CIRCLE_SHA1"
+            echo "export VERSION="$CIRCLE_SHA1"" >> properties.env
             echo "export DOCKER_TAG=\"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$VERSION\"" >> properties.env
             cat properties.env >> $BASH_ENV
       - restore_cache:
@@ -39,7 +29,7 @@ jobs:
       - run:
           name: Hent dependencies
           command: |
-            mvn dependency:go-offline
+            mvn --settings .m2/maven-settings.xml dependency:go-offline
       - save_cache:
           paths:
             - ~/.m2
@@ -47,7 +37,7 @@ jobs:
       - run:
           name: Bygger produksjon
           command: |
-            mvn clean package
+            mvn --settings .m2/maven-settings.xml clean package
       - persist_to_workspace:
           root: /home/circleci/project
           paths:
@@ -71,7 +61,7 @@ jobs:
       - attach_workspace:
           at: /home/circleci/project
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           name: Set up environment variables
           command: cat /home/circleci/project/properties.env >> $BASH_ENV
@@ -91,31 +81,21 @@ jobs:
           paths:
             - properties.env
 
-  github_tag:
+  github_app:
     docker:
       - image: circleci/buildpack-deps:stretch
     steps:
-      - attach_workspace:
-          at: /home/circleci/project
       - run:
-          name: Set up environment variables
+          name: Creating Github Apps Installation Token
           command: |
-            cat /home/circleci/project/properties.env >> $BASH_ENV
-      - run:
-          name: Add github to known hosts
-          command: |
-            mkdir ~/.ssh
-            echo "github.com,140.82.118.3 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
-      - add_ssh_keys:
-          fingerprints:
-            - "73:fc:5a:28:30:60:a6:5d:3d:79:ab:e4:54:3f:4e:72"
-      - run:
-          name: Github tag
-          command: |
-            git config --global user.email "team.familie@nav.no"
-            git config --global user.name "teamfamilie"
-            git tag -a $VERSION -m "$VERSION [skip ci]"
-            git push --tags
+            git clone https://github.com/navikt/github-apps-support.git
+            export PATH=`pwd`/github-apps-support/bin:$PATH
+            echo $GITHUB_PRIVATE_KEY | base64 --decode > ./github.key.pem
+            GITHUB_TOKEN=$(generate-installation-token.sh `generate-jwt.sh ./github.key.pem $GITHUB_APP_ID`)
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./github.key.pem
 
   deploy_dev:
     executor: nais-deployer
@@ -133,11 +113,10 @@ jobs:
               --cluster=dev-sbs \
               --repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
               --appid=${GITHUB_APP_ID} \
-              --key-base64=${GITHUB_PRIVATE_KEY} \
               --team=${TEAM} \
               --version=${VERSION} \
-              --resource=./app-preprod.yaml \
-              --ref=$CIRCLE_BRANCH
+              --key=/home/circleci/project/github.key.pem \
+              --resource=./nais-dev.yaml
 
   deploy_prod:
     executor: nais-deployer
@@ -155,80 +134,48 @@ jobs:
               --cluster=prod-sbs \
               --repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
               --appid=${GITHUB_APP_ID} \
-              --key-base64=${GITHUB_PRIVATE_KEY} \
               --team=${TEAM} \
               --version=${VERSION} \
-              --resource=./app-prod.yaml \
-              --ref=$CIRCLE_BRANCH
+              --key=/home/circleci/project/github.key.pem \
+              --resource=./nais-prod.yaml
 
 workflows:
   version: 2
-  build_n_deploy_master:
+  build_n_deploy:
     jobs:
       - build:
           filters:
-            branches:
-              only: master
+            tags:
+              only: /^v[0-9]+\.[0-9]+$/
       - deploy_docker:
           context: NAIS deployment
           requires:
             - build
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+$/
+      - github_app:
+          context: familie-ci
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+$/
       - deploy_dev:
           context: familie-ci
           requires:
             - deploy_docker
-      - slack/approval-notification:
-          context: familie-ci
-          mentions: 'here'
-          message: Godkjenn deploy av branchen \`master\` til \`prod-sbs\`
+            - github_app
           filters:
+            tags:
+              only: /^.*/
             branches:
-              ignore: /pull\/.*/
-          requires:
-            - deploy_dev
-      - await-approval-dev:
-          context: familie-ci
-          type: approval
-          filters:
-            branches:
-              ignore: /pull\/.*/
-          requires:
-            - deploy_dev
-      - github_tag:
-          context: familie-ci
-          requires:
-            - await-approval-dev
+              only: /.*/
       - deploy_prod:
           context: familie-ci
           requires:
-            - github_tag
-  build_n_deploy_branch:
-    jobs:
-      - build:
-          filters:
-            branches:
-              ignore: master
-      - deploy_docker:
-          context: NAIS deployment
-          requires:
-            - build
-      - slack/approval-notification:
-          context: familie-ci
-          message: Godkjenn deploy av branchen \`${CIRCLE_BRANCH}\` til \`dev-sbs\`
-          filters:
-            branches:
-              ignore: /pull\/.*/
-          requires:
             - deploy_docker
-      - await-approval:
-          context: familie-ci
-          type: approval
+            - github_app
           filters:
+            tags:
+              only: /^.*/
             branches:
-              ignore: /pull\/.*/
-          requires:
-            - deploy_docker
-      - deploy_dev:
-          context: familie-ci
-          requires:
-            - await-approval
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
               --team=${TEAM} \
               --version=${VERSION} \
               --key=/home/circleci/project/github.key.pem \
-              --resource=./nais-dev.yaml
+              --resource=./app-preprod.yaml
 
   deploy_prod:
     executor: nais-deployer
@@ -137,7 +137,7 @@ jobs:
               --team=${TEAM} \
               --version=${VERSION} \
               --key=/home/circleci/project/github.key.pem \
-              --resource=./nais-prod.yaml
+              --resource=./app-prod.yaml
 
 workflows:
   version: 2

--- a/.m2/maven-settings.xml
+++ b/.m2/maven-settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${GITHUB_USERNAME}</username>
+            <password>${GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -35,6 +35,7 @@ spec:
       cpu: 500m
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.
     - https://familie-dokument.nais.oera-q.local
+    - https://www-q0.nav.no/familie/alene-med-barn/mellomlagring
   secureLogs:
     enabled: true
   env:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>no.nav</groupId>
     <packaging>jar</packaging>
     <artifactId>familie-dokument</artifactId>
-    <version>${revision}${sha1}${changelist}</version>
+    <version>1.0${sha1}</version>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -24,7 +24,16 @@
         <felles.version>1.0_20191106113227_c2ad869</felles.version>
         <mockk.version>1.9.3</mockk.version>
         <token-validation-spring.version>1.1.3</token-validation-spring.version>
+        <kontrakter.version>2.0_20200130150253_a5d2e65</kontrakter.version>
      </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/navikt/familie-kontrakter</url>
+        </repository>
+    </repositories>
+
 
     <dependencies>
         <!-- Spring Boot -->
@@ -80,6 +89,11 @@
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>http-client</artifactId>
             <version>${felles.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.familie.kontrakter</groupId>
+            <artifactId>felles</artifactId>
+            <version>${kontrakter.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.security</groupId>

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -63,7 +63,7 @@ class StorageController(@Autowired val storage: AttachmentStorage,
             log.debug("Loaded file with {}", data)
             return ResponseEntity.ok(Ressurs.Companion.success(data))
         } catch (e: RuntimeException) {
-            return ResponseEntity.ok(Ressurs.Companion.failure(e.message))
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Ressurs.Companion.failure(e.message))
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -58,10 +58,13 @@ class StorageController(@Autowired val storage: AttachmentStorage,
     fun getAttachment(@PathVariable("bucket") bucket: String,
                       @PathVariable("dokumentId") dokumentId: String): ResponseEntity<Ressurs<ByteArray>> {
         val directory = contextHolder.hentFnr()
-        val data = storage[directory, dokumentId].orElse(null)
-        log.debug("Loaded file with {}", data)
-        return if (data.isNotEmpty()) ResponseEntity.ok().body(Ressurs.Companion.success(data))
-        else ResponseEntity.ok().body(Ressurs.Companion.failure("Vedlegg med id $dokumentId ikke funnet i bucket $bucket"))
+        try {
+            val data = storage[directory, dokumentId].orElse(null)
+            log.debug("Loaded file with {}", data)
+            return ResponseEntity.ok().body(Ressurs.Companion.success(data))
+        } catch (e: RuntimeException) {
+            return ResponseEntity.ok().body(Ressurs.Companion.failure(e.message))
+        }
     }
 
     @Unprotected

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -54,7 +54,7 @@ class StorageController(@Autowired val storage: AttachmentStorage,
     }
 
     /// TODO: "bucket"-path brukes ikke ennå. "familievedlegg" brukes alltid
-    @GetMapping(path = ["{bucket}/{dokumentId}"], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
+    @GetMapping(path = ["{bucket}/{dokumentId}"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun getAttachment(@PathVariable("bucket") bucket: String,
                       @PathVariable("dokumentId") dokumentId: String): ResponseEntity<Ressurs<ByteArray>> {
         val directory = contextHolder.hentFnr()

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.dokument.storage
 
 import no.nav.familie.dokument.storage.attachment.AttachmentStorage
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.api.Unprotected
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -58,6 +59,12 @@ class StorageController(@Autowired val storage: AttachmentStorage,
         val data = storage[directory, dokumentId].orElse(null)
         log.debug("Loaded file with {}", data)
         return data
+    }
+
+    @Unprotected
+    @GetMapping(path = ["ping"], produces = [MediaType.TEXT_PLAIN_VALUE])
+    fun ping(): String {
+        return "pong"
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -61,16 +61,16 @@ class StorageController(@Autowired val storage: AttachmentStorage,
         try {
             val data = storage[directory, dokumentId].orElse(null)
             log.debug("Loaded file with {}", data)
-            return ResponseEntity.ok().body(Ressurs.Companion.success(data))
+            return ResponseEntity.ok(Ressurs.Companion.success(data))
         } catch (e: RuntimeException) {
-            return ResponseEntity.ok().body(Ressurs.Companion.failure(e.message))
+            return ResponseEntity.ok(Ressurs.Companion.failure(e.message))
         }
     }
 
     @Unprotected
     @GetMapping(path = ["ping"], produces = [MediaType.TEXT_PLAIN_VALUE])
     fun ping(): String {
-        return "pong"
+        return "Kontakt med familie-dokument"
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -60,7 +60,8 @@ class StorageController(@Autowired val storage: AttachmentStorage,
         val directory = contextHolder.hentFnr()
         val data = storage[directory, dokumentId].orElse(null)
         log.debug("Loaded file with {}", data)
-        return ResponseEntity.ok(Ressurs.Companion.success(data))
+        return if (data.isNotEmpty()) ResponseEntity.ok().body(Ressurs.Companion.success(data))
+        else ResponseEntity.ok().body(Ressurs.Companion.failure("Vedlegg med id $dokumentId ikke funnet i bucket $bucket"))
     }
 
     @Unprotected

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.dokument.storage
 
 import no.nav.familie.dokument.storage.attachment.AttachmentStorage
+import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.security.token.support.core.api.Unprotected
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.io.ByteArrayInputStream
@@ -54,11 +56,11 @@ class StorageController(@Autowired val storage: AttachmentStorage,
     /// TODO: "bucket"-path brukes ikke ennå. "familievedlegg" brukes alltid
     @GetMapping(path = ["{bucket}/{dokumentId}"], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
     fun getAttachment(@PathVariable("bucket") bucket: String,
-                      @PathVariable("dokumentId") dokumentId: String): ByteArray {
+                      @PathVariable("dokumentId") dokumentId: String): ResponseEntity<Ressurs<ByteArray>> {
         val directory = contextHolder.hentFnr()
         val data = storage[directory, dokumentId].orElse(null)
         log.debug("Loaded file with {}", data)
-        return data
+        return ResponseEntity.ok(Ressurs.Companion.success(data))
     }
 
     @Unprotected

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -3,7 +3,6 @@ cors:
     - "https://familie-ef-soknad.nais.oera-q.local"
     - "https://www-q0.nav.no/familie/alene-med-barn/soknad"
     - "https://familie-ef-soknad-api.nais.oera-q.local"
-    - "https://www-q0.nav.no/familie/alene-med-barn/soknad-api"
 
 no.nav.security.jwt:
   issuers: selvbetjening

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -2,6 +2,8 @@ cors:
   allowed_origins:
     - "https://familie-ef-soknad.nais.oera-q.local"
     - "https://www-q0.nav.no/familie/alene-med-barn/soknad"
+    - "https://familie-ef-soknad-api.nais.oera-q.local"
+    - "https://www-q0.nav.no/familie/alene-med-barn/soknad-api"
 
 no.nav.security.jwt:
   issuers: selvbetjening

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ cors:
   allowed_origins:
     - "https://familie-ef-soknad.nais.oera.no"
     - "https://www.nav.no/familie/alene-med-barn/soknad"
-    - "https://www.nav.no"
+    - "https://familie-ef-soknad-api.nais.oera.no"
 
 no.nav.security.jwt:
   issuers: selvbetjening

--- a/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3InitializerTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3InitializerTest.kt
@@ -3,7 +3,9 @@ package no.nav.familie.dokument.storage.s3
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.testcontainers.containers.localstack.LocalStackContainer
@@ -12,7 +14,8 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
-@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
+//@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
+@Disabled
 class S3InitializerTest {
 
     private val SIZE_MB = 20

--- a/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3InitializerTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3InitializerTest.kt
@@ -3,9 +3,7 @@ package no.nav.familie.dokument.storage.s3
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.testcontainers.containers.localstack.LocalStackContainer
@@ -14,8 +12,7 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
 @Testcontainers
-//@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
-@Disabled
+@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
 class S3InitializerTest {
 
     private val SIZE_MB = 20

--- a/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3StorageTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3StorageTest.kt
@@ -10,12 +10,10 @@ import org.testcontainers.junit.jupiter.Testcontainers
 import java.io.ByteArrayInputStream
 
 import org.junit.Assert.assertEquals
-import org.junit.jupiter.api.Disabled
 import org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
 
 @Testcontainers
-@Disabled
-//@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
+@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
 class S3StorageTest {
 
     @Container

--- a/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3StorageTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/s3/S3StorageTest.kt
@@ -1,9 +1,5 @@
 package no.nav.familie.dokument.storage.s3
 
-import com.amazonaws.services.s3.AmazonS3
-import io.mockk.every
-import io.mockk.mockk
-import org.junit.Assert
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
@@ -14,13 +10,12 @@ import org.testcontainers.junit.jupiter.Testcontainers
 import java.io.ByteArrayInputStream
 
 import org.junit.Assert.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.testcontainers.containers.localstack.LocalStackContainer.Service.S3
-import java.nio.charset.Charset
-import java.util.*
 
 @Testcontainers
-@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
+@Disabled
+//@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
 class S3StorageTest {
 
     @Container
@@ -39,11 +34,11 @@ class S3StorageTest {
 
     @Test
     fun testStorage() {
-        storage!!.put("dir", "file", ByteArrayInputStream("asdfasdf".toByteArray()))
-        storage!!.put("dir", "file2", ByteArrayInputStream("asdfasdf2".toByteArray()))
+        storage!!.put("dir", "file", ByteArrayInputStream("testeksempel1".toByteArray()))
+        storage!!.put("dir", "file2", ByteArrayInputStream("testeksempel2".toByteArray()))
 
-        assertEquals("asdfasdf",String(storage!!["dir", "file"].orElse(null)))
-        assertEquals("asdfasdf2",String(storage!!["dir", "file2"].orElse(null)))
+        assertEquals("testeksempel1",String(storage!!["dir", "file"].orElse(null)))
+        assertEquals("testeksempel2",String(storage!!["dir", "file2"].orElse(null)))
     }
 
 }


### PR DESCRIPTION
Små endringer i forbindelse med henting av vedlegg i api: 
- Ta i bruk kontrakter og returner vedlegg som ressurs
- Oppdaterer byggepipeline: fjern slack-bekreftelse og hent github-pakker
- Legg til ping-endepunkt

Tenker virussjekk og eventuell endring i bøttestruktur kan oppdateres etter gcp-flytt og evt overgang til cloud storage. Altså brukes fortsatt kun en default bucket - _familievedlegg_. 