### PR TITLE
Nav gcp ingress

### DIFF
--- a/.deploy/dev-gcp.json
+++ b/.deploy/dev-gcp.json
@@ -1,5 +1,5 @@
 {
-  "ingresses": ["https://familie-dokument.dev.intern.nav.no", "https://familie-dokument.dev.nav.no/familie/dokument"],
+  "ingresses": ["https://familie-dokument.dev.intern.nav.no", "https://dev.nav.no/familie/dokument"],
   "bucket_name" : "familie-dokument-dev",
   "spring_profile" : "preprod, debug",
   "secret" : "familie-dokument-secret-dev"

--- a/.deploy/dev-gcp.json
+++ b/.deploy/dev-gcp.json
@@ -1,5 +1,5 @@
 {
-  "ingresses": ["https://familie-dokument.dev.intern.nav.no", "https://dev.nav.no/familie/dokument"],
+  "ingresses": ["https://familie-dokument.dev.intern.nav.no", "https://familie-dokument.dev.nav.no/familie/dokument"],
   "bucket_name" : "familie-dokument-dev",
   "spring_profile" : "preprod, debug",
   "secret" : "familie-dokument-secret-dev"

--- a/.deploy/dev-gcp.json
+++ b/.deploy/dev-gcp.json
@@ -1,5 +1,5 @@
 {
-  "ingresses": ["https://familie-dokument.dev.intern.nav.no", "https://familie-dokument.dev.nav.no"],
+  "ingresses": ["https://familie-dokument.dev.intern.nav.no", "https://familie-dokument.dev.nav.no/familie/dokument"],
   "bucket_name" : "familie-dokument-dev",
   "spring_profile" : "preprod, debug",
   "secret" : "familie-dokument-secret-dev"

--- a/.deploy/prod-gcp.json
+++ b/.deploy/prod-gcp.json
@@ -1,5 +1,5 @@
 {
-  "ingresses": ["https://familie-dokument.intern.nav.no", "https://familie-dokument.nav.no"],
+  "ingresses": ["https://familie-dokument.intern.nav.no", "https://www.nav.no/familie/dokument"],
   "bucket_name" : "familie-dokument",
   "spring_profile" : "prod",
   "secret" : "familie-dokument-secret"

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StonadController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StonadController.kt
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("api/soknad")
+@RequestMapping("familie/dokument/api/soknad", "api/soknad")
 @ProtectedWithClaims(issuer = "selvbetjening", claimMap = ["acr=Level4"])
 class StonadController(@Autowired val storage: MellomLagerService,
                        @Autowired val contextHolder: TokenValidationContextHolder,

--- a/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/StorageController.kt
@@ -18,15 +18,12 @@ import org.springframework.web.multipart.MultipartFile
 import java.util.*
 
 @RestController
-@RequestMapping("api/mapper")
+@RequestMapping("familie/dokument/api/mapper", "api/mapper")
 @ProtectedWithClaims(issuer = "selvbetjening", claimMap = ["acr=Level4"])
 class StorageController(@Autowired val storage: AttachmentStorage,
                         @Autowired val contextHolder: TokenValidationContextHolder,
                         @Value("\${attachment.max.size.mb}") val maxFileSizeInMb: Int,
                         @Autowired val hasher: Hasher) {
-
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
-
 
     /// TODO: "bucket"-path brukes ikke ennå. "familievedlegg" brukes alltid
     @PostMapping(path = ["{bucket}"],

--- a/src/test/kotlin/no/nav/familie/dokument/storage/integrationTest/StonadControllerIntegrasionTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/integrationTest/StonadControllerIntegrasionTest.kt
@@ -59,7 +59,7 @@ class StonadControllerIntegrasionTest {
             blob
         }
 
-        mockMvc.post("/api/soknad/{stonad}", "barnetilsyn") {
+        mockMvc.post("/familie/dokument/api/soknad/{stonad}", "barnetilsyn") {
             contentType = MediaType.APPLICATION_JSON
             content = gyldigJson
             accept = MediaType.APPLICATION_JSON
@@ -71,7 +71,7 @@ class StonadControllerIntegrasionTest {
     @Test
     fun `Skal returnere 400 for søknad som er ugyldig json`() {
         val ugyldigJson = """ { "søknad""""
-        mockMvc.post("/api/soknad/{stonad}", "barnetilsyn") {
+        mockMvc.post("/familie/dokument/api/soknad/{stonad}", "barnetilsyn") {
             contentType = MediaType.APPLICATION_JSON
             content = ugyldigJson
             accept = MediaType.APPLICATION_JSON
@@ -86,7 +86,7 @@ class StonadControllerIntegrasionTest {
         every{tokenValidationContextHolderMock.hentFnr()} returns TEST_FNR
         every{storageMock.create(any(), any<ByteArray>())} throws StorageException(HttpStatus.UNAUTHORIZED.value(), "Unauthorized");
 
-        mockMvc.post("/api/soknad/{stonad}", "barnetilsyn") {
+        mockMvc.post("/familie/dokument/api/soknad/{stonad}", "barnetilsyn") {
             contentType = MediaType.APPLICATION_JSON
             content = gyldigJson
             accept = MediaType.APPLICATION_JSON
@@ -109,7 +109,7 @@ class StonadControllerIntegrasionTest {
 
         every{storageMock.get(any<BlobId>()) } returns blob
 
-        mockMvc.post("/api/soknad/{stonad}", "barnetilsyn") {
+        mockMvc.post("/familie/dokument/api/soknad/{stonad}", "barnetilsyn") {
             contentType = MediaType.APPLICATION_JSON
             content = gyldigJson
             accept = MediaType.APPLICATION_JSON
@@ -117,7 +117,7 @@ class StonadControllerIntegrasionTest {
             status { isCreated }
         }
 
-        mockMvc.get("/api/soknad/barnetilsyn") {
+        mockMvc.get("/familie/dokument/api/soknad/barnetilsyn") {
             accept = MediaType.APPLICATION_JSON
         }.andExpect {
             status { isOk }
@@ -130,7 +130,7 @@ class StonadControllerIntegrasionTest {
         every{tokenValidationContextHolderMock.hentFnr()} returns TEST_FNR
         every{storageMock.get(any<BlobId>()) } returns null
 
-        mockMvc.get("/api/soknad/barnetilsyn") {
+        mockMvc.get("/familie/dokument/api/soknad/barnetilsyn") {
             accept = MediaType.APPLICATION_JSON
         }.andExpect {
             status { isNoContent }


### PR DESCRIPTION
Fant ingen god måte å håndtere 2 context-path på. 
Har løst den en gang med rewrite-filter/interceptor men dette får være tilstrekkelig nå. 

Gjør det mulig for nav.no og forholde seg til nav.no**/familie/dokument/api**
Og for ef/ba -sak til familie-dokument.intern.nav.no**/api/**