### PR TITLE
Setter lifecycle til 2 dager for gcp bucket sånn att mellomlagringer …

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -92,3 +92,4 @@ spec:
     buckets:
       - name: {{bucket_name}}
         cascadingDelete: false
+        age: 2


### PR DESCRIPTION
…og vedlegg slettes etter 2 dager for å ikke lagre informasjon lengre enn vi trenger

Denne må likevel bestilles fra NAIS, då nye regler ikke overstyrer de som fantes når storage sattes opp, men fint å få inn denne nå likevel hvis det er sånn att oppdateringene blir aktive. 