### PR TITLE
Skal få sende med consumer-id fra klieter for å logge hvilken app sok…

### DIFF
--- a/src/main/kotlin/no/nav/familie/dokument/config/CORSResponseFilter.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/config/CORSResponseFilter.kt
@@ -31,7 +31,7 @@ class CORSResponseFilter(val corsProperties: CorsProperties) : Filter {
 
     private fun setCorsHeaders(response: HttpServletResponse, request: HttpServletRequest) {
         response.addHeader("Access-Control-Allow-Origin", request.getHeader("Origin"))
-        response.addHeader("Access-Control-Allow-Headers", "origin, content-type, content-length, accept, authorization")
+        response.addHeader("Access-Control-Allow-Headers", "origin, content-type, content-length, accept, authorization, nav-consumer-id")
         response.addHeader("Access-Control-Allow-Credentials", "true")
         response.addHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS, HEAD")
     }


### PR DESCRIPTION
…nad/ettersending som kallet på api

Dette er pga ettersending som kjører på et annet subdomene i dev, men like greit å ta med den her likevel
`Access to XMLHttpRequest at 'https://familie.dev.nav.no/familie/alene-med-barn/soknad-api/api/oppslag/sokerinfo' from origin 'https://ensligmorellerfar.dev.nav.no' has been blocked by CORS policy: Request header field nav-consumer-id is not allowed by Access-Control-Allow-Headers in preflight response.`