### PR TITLE
Då vi kun bruker Tika for å identifisere hvilken type dokument det er…

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,6 +36,8 @@
     <logger name="org.apache.cxf" level="ERROR"/>
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
+    <logger name="org.apache.pdfbox.pdmodel.font.PDFont" level="ERROR"/>
+    <logger name="org.apache.pdfbox.pdmodel.font.PDSimpleFont" level="ERROR"/>
     <logger name="org.apache.pdfbox.pdmodel.font.PDType0Font" level="ERROR"/>
     <logger name="org.apache.pdfbox.pdmodel.font.PDType1Font" level="ERROR"/>
     <logger name="org.apache.pdfbox.pdmodel.font.PDTrueTypeFont" level="ERROR"/>


### PR DESCRIPTION
… så trenger vi ikke å logge warning på "No Unicode mapping for ... in font ..."

Hadde kanskje kunnet satt ERROR på hela pakken og sen lagt inn WARN på noen spesifika klasser, men ikke helt sikker på hvilke vi burde ha med, så tar error på de vi finner att vi ikke trenger 

Relatert til https://github.com/navikt/familie-dokument/pull/175
