### PR TITLE
Prøver å lage pdImage med lossless factory hvis jpeg feiler

### DIFF
--- a/src/main/kotlin/no/nav/familie/dokument/storage/attachment/ImageConversionService.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/attachment/ImageConversionService.kt
@@ -7,6 +7,7 @@ import org.apache.pdfbox.pdmodel.PDPage
 import org.apache.pdfbox.pdmodel.PDPageContentStream
 import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.graphics.image.JPEGFactory
+import org.apache.pdfbox.pdmodel.graphics.image.LosslessFactory
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
 import org.apache.pdfbox.util.Matrix
 import org.slf4j.LoggerFactory
@@ -34,25 +35,43 @@ class ImageConversionService {
 
             val portraitImage = toPortrait(image, detectedType)
 
-            val quality = 1.0f
 
             logger.info("Konverterer detectedType=$detectedType imageType=${image.type} portraitImageType=${portraitImage.type}")
-            val pdImage = JPEGFactory.createFromImage(document, portraitImage, quality)
+            val pdImage = createPdImage(document, portraitImage, detectedType)
             val imageSize = scale(pdImage, page)
-
-            logger.info(
-                "Input format=${detectedType.name} h=${image.height} w=${image.width} " +
-                    "Portrait h=${portraitImage.height} w=${portraitImage.width} " +
-                    "ImageSize height=${imageSize.height} width=${imageSize.width} " +
-                    " lowHeight=${imageSize.height < page.cropBox.height} lowWidth=${imageSize.width < page.cropBox.width}"
-            )
 
             PDPageContentStream(document, page, PDPageContentStream.AppendMode.APPEND, false).use {
                 it.drawImage(pdImage, Matrix(imageSize.width, 0f, 0f, imageSize.height, 0f, 0f))
             }
             val byteArrayOutputStream = ByteArrayOutputStream()
             document.save(byteArrayOutputStream)
-            byteArrayOutputStream.toByteArray()
+            val outputBytes = byteArrayOutputStream.toByteArray()
+            logger.info(
+                "Input format=${detectedType.name} h=${image.height} w=${image.width} " +
+                    "Portrait h=${portraitImage.height} w=${portraitImage.width} " +
+                    "ImageSize height=${imageSize.height} width=${imageSize.width} " +
+                    " lowHeight=${imageSize.height < page.cropBox.height} lowWidth=${imageSize.width < page.cropBox.width}" +
+                    " inputSize=${input.size / 1024} diffSize=${outputBytes.size / input.size} "
+            )
+            outputBytes
+        }
+    }
+
+    private fun createPdImage(
+        document: PDDocument,
+        portraitImage: BufferedImage,
+        detectedType: Format
+    ): PDImageXObject {
+        val quality = 1.0f
+        return try {
+            JPEGFactory.createFromImage(document, portraitImage, quality)
+        } catch (e: Exception) {
+            if (detectedType == Format.PNG) {
+                logger.warn("Feilet konvertering av jpegbilde, prøver med lossless", e)
+                LosslessFactory.createFromImage(document, portraitImage)
+            } else {
+                throw e
+            }
         }
     }
 


### PR DESCRIPTION
Noen andre har gjort liknende 
https://github.com/search?q=org%3Anavikt+LosslessFactory&type=code

Har dessverre ikke skjønt hvordan dette burde testes, vet ikke hvilken type bilder som faktiskt feiler

https://pdfbox.apache.org/2.0/migration.html -> Working with Images

> * JPEGFactory.createFromStream which preserve the JPEG data and embed it in the PDF file without modification. (This is best if you have a JPEG file).
> * CCITTFactory.createFromFile (for bitonal TIFF images with G4 compression).
> * LosslessFactory.createFromImage (this is best if you start with a BufferedImage).