### PR TITLE
Fjern CPU-limit

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -36,11 +36,9 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 80
   resources:
     limits:
       memory: 4Gi
-      cpu: "1"
     requests:
       memory: 2Gi
       cpu: 500m

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -36,11 +36,9 @@ spec:
   replicas:
     min: 2
     max: 4
-    cpuThresholdPercentage: 80
   resources:
     limits:
       memory: 4Gi
-      cpu: "1"
     requests:
       memory: 2Gi
       cpu: 500m


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)