### PR TITLE
Legg til inboundregel for ba-søknad på gammel url i tillegg til ny

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -55,6 +55,7 @@ spec:
         - application: familie-ef-soknad
         - application: familie-baks-soknad-api
         - application: familie-ba-soknad
+        - application: familie-ba-soknad-gammel-url
         - application: familie-ks-soknad
         - application: familie-baks-mottak
         - application: familie-ef-ettersending

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -55,6 +55,7 @@ spec:
         - application: familie-ef-sak
         - application: familie-baks-soknad-api
         - application: familie-ba-soknad
+        - application: familie-ba-soknad-gammel-url
         - application: familie-ks-soknad
         - application: familie-baks-mottak
         - application: familie-ef-soknad


### PR DESCRIPTION
Mens vi endrer URL til ba-søknad har vi i en periode to apper kjørende, med ulike navn og URLer. Legger til støtte for begge

https://github.com/navikt/familie-ba-soknad/pull/1126
Samme endring som i baks-api:
https://github.com/navikt/familie-baks-soknad-api/pull/204