### PR TITLE
Fjerner familie-ba-soknad-gammel-url fra inbound rules

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -55,7 +55,6 @@ spec:
         - application: familie-ef-soknad
         - application: familie-baks-soknad-api
         - application: familie-ba-soknad
-        - application: familie-ba-soknad-gammel-url
         - application: familie-ks-soknad
         - application: familie-baks-mottak
         - application: familie-ef-ettersending

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -55,7 +55,6 @@ spec:
         - application: familie-ef-sak
         - application: familie-baks-soknad-api
         - application: familie-ba-soknad
-        - application: familie-ba-soknad-gammel-url
         - application: familie-ks-soknad
         - application: familie-baks-mottak
         - application: familie-ef-soknad


### PR DESCRIPTION
Ble lagt inn i forbindelse med at det ble satt opp en egen app i kubernetes som skulle bruke gammel url. Brukes ikke lenger så fjerner det.