### PR TITLE
Endrer conformance fra PDFA_2_U til PDFA_2_A (Accessible) i PdfService

### DIFF
--- a/src/main/kotlin/no/nav/familie/dokument/pdf/PdfService.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/pdf/PdfService.kt
@@ -103,7 +103,7 @@ class PdfService {
 
             val id = xmp.createAndAddPFAIdentificationSchema()
             id.part = 2
-            id.conformance = "U"
+            id.conformance = "A"
 
             val serializer = XmpSerializer()
             val baos = ByteArrayOutputStream()

--- a/src/test/kotlin/no/nav/familie/dokument/pdf/PdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/pdf/PdfGeneratorTest.kt
@@ -111,7 +111,7 @@ class PdfGeneratorTest {
 
     private fun isPDF_2_ACompliant(pdf: ByteArray): Boolean {
         VeraGreenfieldFoundryProvider.initialise()
-        val pdfaFlavour = PDFAFlavour.PDFA_2_U
+        val pdfaFlavour = PDFAFlavour.PDFA_2_A
         val validator = Foundries.defaultInstance().createValidator(pdfaFlavour, false)
         val parser = Foundries.defaultInstance().createParser(ByteArrayInputStream(pdf))
         return validator.validate(parser).isCompliant


### PR DESCRIPTION
men uten at det kastes feil for html-filer som ikke oppfyller alle krav.

[Favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-19966) og tilhørende pr i familie-brev: https://github.com/navikt/familie-brev/pull/654
