### PR TITLE
Skru til errorlogging for fonter samt feilhåndtere ugyldig filformat …

### DIFF
--- a/src/main/kotlin/no/nav/familie/dokument/ApiExceptions.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/ApiExceptions.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.dokument
 
+import no.nav.familie.dokument.BadRequestCode.INVALID_DOCUMENT_FORMAT
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.ResponseStatus
 
@@ -12,6 +13,8 @@ class InvalidDocumentSize(code: BadRequestCode) : BadRequestException(code)
 
 class InvalidImageDimensions(code: BadRequestCode) : BadRequestException(code)
 
+class InvalidDocumentFormat(message: String) : BadRequestException(INVALID_DOCUMENT_FORMAT, message)
+
 @ResponseStatus(HttpStatus.NOT_FOUND)
 class GcpDocumentNotFound : RuntimeException("Finner ikke dokumentet i Google Storage")
 
@@ -19,5 +22,6 @@ enum class BadRequestCode {
     DOCUMENT_MISSING,
     IMAGE_TOO_LARGE,
     IMAGE_DIMENSIONS_TOO_SMALL,
+    INVALID_DOCUMENT_FORMAT,
     VIRUS_FOUND,
 }

--- a/src/main/kotlin/no/nav/familie/dokument/storage/attachment/AttachmentToStorableFormatConverter.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/attachment/AttachmentToStorableFormatConverter.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.dokument.storage.attachment
 
+import no.nav.familie.dokument.InvalidDocumentFormat
 import org.apache.tika.Tika
 
 class AttachmentToStorableFormatConverter(
@@ -10,7 +11,7 @@ class AttachmentToStorableFormatConverter(
     fun toStorageFormat(input: ByteArray): ByteArray {
         val mimeType = Tika().detect(input)
         val detectedType = Format.fromMimeType(mimeType)
-            .orElseThrow { RuntimeException("Kunne ikke konvertere vedleggstypen $mimeType") }
+            .orElseThrow { InvalidDocumentFormat("Kunne ikke konvertere vedleggstypen $mimeType") }
 
         return if (Format.PDF == detectedType) {
             flattenPdfService.convert(input)

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -41,5 +41,6 @@
     <logger name="org.apache.pdfbox.pdmodel.font.PDType0Font" level="ERROR"/>
     <logger name="org.apache.pdfbox.pdmodel.font.PDType1Font" level="ERROR"/>
     <logger name="org.apache.pdfbox.pdmodel.font.PDTrueTypeFont" level="ERROR"/>
+    <logger name="org.apache.pdfbox.pdmodel.font.FileSystemFontProvider" level="ERROR"/>
 
 </configuration>

--- a/src/test/kotlin/no/nav/familie/dokument/storage/attachment/AttachmentConverterTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/attachment/AttachmentConverterTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.dokument.storage.attachment
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import no.nav.familie.dokument.InvalidDocumentFormat
 import no.nav.familie.dokument.TestUtil.toByteArray
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -25,7 +26,7 @@ class AttachmentConverterTest {
     @Test
     fun at_ulovlig_format_kaster_exception() {
         val txtVedlegg = toByteArray("dummy/txt_dummy.txt")
-        assertThatThrownBy { converter.toStorageFormat(txtVedlegg) }.isInstanceOf(RuntimeException::class.java)
+        assertThatThrownBy { converter.toStorageFormat(txtVedlegg) }.isInstanceOf(InvalidDocumentFormat::class.java)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/dokument/storage/integrationTest/StorageControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/storage/integrationTest/StorageControllerIntegrationTest.kt
@@ -72,7 +72,7 @@ class StorageControllerIntegrationTest : OppslagSpringRunnerTest() {
             HttpMethod.POST,
             HttpEntity(vedlegg, headers),
         )
-        assertThat(response.statusCode).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
     @Test


### PR DESCRIPTION
…som 400 bad request, istedenfor 500 som skaper unødig støy i loggene