### PR TITLE
Legg til auto-instrumentation

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -29,6 +29,10 @@ spec:
   prometheus:
     enabled: true
     path: /internal/prometheus
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
   vault:
     enabled: true
   replicas:

--- a/.deploy/nais-prod.yaml
+++ b/.deploy/nais-prod.yaml
@@ -29,6 +29,10 @@ spec:
   prometheus:
     enabled: true
     path: /internal/prometheus
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
   vault:
     enabled: true
   replicas:


### PR DESCRIPTION
Skrur på NAIS auto-instrumentation, som bruker OpenTelemetry for å samle inn telemetri. I vårt tilfelle tracing-data.

https://docs.nais.io/observability/how-to/auto-instrumentation/