### PR TITLE
Bumper familie-felles slik at vi på søknadene ikke oppretter tracking-cookien RUIDC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jvmTarget>21</jvmTarget>
         <main-class>no.nav.familie.dokument.LauncherKt</main-class> 
-        <felles.version>3.20250106100611_6ae49d2</felles.version>
+        <felles.version>3.20250122103549_5bcb4dc</felles.version>
         <kotlin.version>2.1.0</kotlin.version>
         <mockk.version>1.13.16</mockk.version>
         <token-validation-spring.version>5.0.14</token-validation-spring.version>

--- a/src/main/kotlin/no/nav/familie/dokument/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/config/ApplicationConfig.kt
@@ -3,6 +3,7 @@ package no.nav.familie.dokument.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.familie.http.interceptor.ConsumerIdClientInterceptor
 import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
 import no.nav.familie.log.filter.RequestTimeFilter
 import org.springframework.boot.SpringBootConfiguration
@@ -31,7 +32,7 @@ class ApplicationConfig {
     @Bean
     fun logFilter(): FilterRegistrationBean<LogFilter> {
         val filterRegistration = FilterRegistrationBean<LogFilter>()
-        filterRegistration.filter = LogFilter()
+        filterRegistration.filter = LogFilter(NavSystemtype.NAV_INTEGRASJON)
         filterRegistration.order = 1
         return filterRegistration
     }


### PR DESCRIPTION
På søknadene (der vi bruker dokument til opplasting av vedlegg) ønsker vi ikke å opprette tracking cookien RUIDC. Men på saksbehandling (der den brukes til å generere brev blant annet) ønsker vi å videreføre RUIDC-cookien som allerede eksisterer på brukeren.

Mer info om denne endringen finnes i denne PRen: https://github.com/navikt/familie-felles/pull/854