### PR TITLE
Retryable på mellomlagring ved 429 feil fra GCP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,14 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>

--- a/src/main/kotlin/no/nav/familie/dokument/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/ApiExceptionHandler.kt
@@ -1,5 +1,6 @@
 package no.nav.familie.dokument
 
+import no.nav.familie.dokument.storage.google.GcpRateLimitException
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import org.slf4j.LoggerFactory
@@ -35,7 +36,11 @@ class ApiExceptionHandler : ResponseEntityExceptionHandler() {
         status: HttpStatus,
         request: WebRequest,
     ): ResponseEntity<Any>? {
-        if (ex is HttpRequestMethodNotSupportedException || ex is HttpMediaTypeNotSupportedException || ex is HttpMediaTypeNotAcceptableException) {
+        if (ex is HttpRequestMethodNotSupportedException ||
+            ex is HttpMediaTypeNotSupportedException ||
+            ex is HttpMediaTypeNotAcceptableException ||
+            ex is GcpRateLimitException
+        ) {
             secureLogger.warn("En feil har oppstått", ex)
             logger.warn("En feil har oppstått - throwable=${rootCause(ex)} status=${status.value()}")
         } else {

--- a/src/main/kotlin/no/nav/familie/dokument/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/config/ApplicationConfig.kt
@@ -14,12 +14,14 @@ import org.springframework.boot.web.servlet.server.ServletWebServerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
+import org.springframework.retry.annotation.EnableRetry
 import org.springframework.web.client.RestOperations
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 
 @SpringBootConfiguration
 @Import(ConsumerIdClientInterceptor::class)
+@EnableRetry
 class ApplicationConfig {
 
     @Bean

--- a/src/main/kotlin/no/nav/familie/dokument/storage/google/GcpStorageWrapper.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/google/GcpStorageWrapper.kt
@@ -5,11 +5,6 @@ import java.io.InputStream
 
 class GcpStorageWrapper(val storage: GcpStorage, val mediaTypeValue: String) : Storage<InputStream, ByteArray> {
 
-//    @Retryable(
-//        retryFor = [GcpRateLimitException::class],
-//        maxAttempts = 3,
-//        backoff = Backoff(delay = 1000),
-//    )
     override fun put(directory: String, key: String, data: InputStream) {
         storage.put(directory, key, data, mediaTypeValue)
     }

--- a/src/main/kotlin/no/nav/familie/dokument/storage/google/GcpStorageWrapper.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/google/GcpStorageWrapper.kt
@@ -5,6 +5,11 @@ import java.io.InputStream
 
 class GcpStorageWrapper(val storage: GcpStorage, val mediaTypeValue: String) : Storage<InputStream, ByteArray> {
 
+//    @Retryable(
+//        retryFor = [GcpRateLimitException::class],
+//        maxAttempts = 3,
+//        backoff = Backoff(delay = 1000),
+//    )
     override fun put(directory: String, key: String, data: InputStream) {
         storage.put(directory, key, data, mediaTypeValue)
     }

--- a/src/main/kotlin/no/nav/familie/dokument/storage/mellomlager/MellomLagerService.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/storage/mellomlager/MellomLagerService.kt
@@ -3,7 +3,10 @@ package no.nav.familie.dokument.storage.mellomlager
 import no.nav.familie.dokument.storage.Storage
 import no.nav.familie.dokument.storage.encryption.EncryptedStorage
 import no.nav.familie.dokument.storage.encryption.EncryptedStorageConfiguration.Companion.STONAD_ENCRYPTED_STORAGE
+import no.nav.familie.dokument.storage.google.GcpRateLimitException
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Service
 import java.io.ByteArrayInputStream
 
@@ -13,6 +16,11 @@ class MellomLagerService internal constructor(
     private val delegate: EncryptedStorage,
 ) : Storage<String, String> {
 
+    @Retryable(
+        retryFor = [GcpRateLimitException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 1000),
+    )
     override fun put(directory: String, key: String, data: String) {
         delegate.put(directory, key, ByteArrayInputStream(data.toByteArray()))
     }


### PR DESCRIPTION
Man får jevnlige alarmer på at man har nådd rate limit ved lagring til bucket i GCP. Dette skjer når det er mye mellomlagring som blir prøvd lagret og man når rate limiten til GCP. Man kan trigge dette enkelt med å slette antall vedlegg i Kontantstøtte.

`com.google.cloud.storage.StorageException: The object familie-dokument-dev/Py5x2p2moLk9vFEihp6g1wR7yEDgqxQDAR+r8KL76Ms=_kontantstotte exceeded the rate limit for object mutation operations (create, update, and delete). Please reduce your request rate. See https://cloud.google.com/storage/docs/gcs429.`

Har lagt på en Retryable på mellomlagringskall put ved StorageException man mottar med kode 429 når dette skjer, og satt loglevel til warning hvis en retryable ikke løser det.

<img width="846" alt="Screenshot 2025-03-25 at 14 08 50" src="https://github.com/user-attachments/assets/8439337c-ea28-4f19-8713-7b73bb705108" />

