### PR TITLE
Endrer namespace for TokeX generator til NAIS

### DIFF
--- a/.deploy/nais-dev.yaml
+++ b/.deploy/nais-dev.yaml
@@ -69,7 +69,7 @@ spec:
         - application: tilleggsstonader-klage
           namespace: tilleggsstonader
         - application: tokenx-token-generator
-          namespace: aura
+          namespace: nais
           cluster: dev-gcp
     outbound:
       rules:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c1f75cad-c4f2-4f9c-b343-0a7d4c71f42a)

Endrer namespace for TokenX generator til NAIS slik det er i familie-ef-soknad-api. Dette lar oss bygge tokens for testing i pre-prod. 

Feil når man prøver å genere token:

```
{
  "error" : "invalid_request",
  "error_description" : "client 'dev-gcp:nais:tokenx-token-generator' is not authorized to get token with aud=dev-gcp:teamfamilie:familie-dokument"
}
```