### PR TITLE
Tuner ressurs settings etter forslag fra nais-console

### DIFF
--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -44,10 +44,10 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 4Gi
+      memory: 2.78Gi
     requests:
       memory: 2Gi
-      cpu: 50m
+      cpu: 532m
   ingresses:
     - https://familie-dokument.intern.nav.no
     - https://www.nav.no/familie/dokument


### PR DESCRIPTION
Så at podder skalerer opp og ned ganske ofte og at den tidvis bruker mer CPU enn reservert. Tuner derfor ressursene i henhold til anbefalt fra nais-consollet for pro-gcp

<img width="1202" height="983" alt="image" src="https://github.com/user-attachments/assets/466b53f9-07ec-4196-a5a9-8e6d15c5765f" />
