### PR TITLE
Fikser ugyldig verdi på memory limits

### DIFF
--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -44,7 +44,7 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 2.78Gi
+      memory: 3Gi
     requests:
       memory: 2Gi
       cpu: 532m


### PR DESCRIPTION
Forslaget til nais matcher ikke regexen til nais 
> invalid value: "2.78Gi": spec.resources.limits.memory in body should match '^\d+[KMG]i$' (total of 1 errors)

