### PR TITLE
Legg til id-token: write permission for scan-vulnerabilities

### DIFF
--- a/.github/workflows/scan-vulnerabilities.yaml
+++ b/.github/workflows/scan-vulnerabilities.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write # to write sarif
       security-events: write # push sarif to github security
+      id-token: write # nais/login
     uses: navikt/familie-baks-gha-workflows/.github/workflows/scan-vulnerabilities-maven.yaml@main # ratchet:exclude
     secrets: inherit
 


### PR DESCRIPTION
### 📮 Favro: NAV-28032

### 💰 Hva skal gjøres, og hvorfor?
Workflow tryner etter chainguard image ble tatt i bruk. Trenger id-token permission for å fikse.