### PR TITLE
Legg til mulighet for å nå åpne endepunkter med azure ad token

### DIFF
--- a/src/main/kotlin/no/nav/familie/dokument/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/dokument/config/SecurityConfig.kt
@@ -8,6 +8,7 @@ import no.nav.familie.kontrakter.felles.jsonMapper
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.http.MediaType
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -28,7 +29,28 @@ class SecurityConfig(
     private val corsProperties: CorsProperties,
 ) {
     @Bean
-    fun securityFilterChain(
+    @Order(1)
+    fun publicFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            securityMatcher(
+                "/internal/**",
+                "/api/html-til-pdf",
+                "/familie/dokument/api/html-til-pdf",
+                "/api/mapper/ping",
+                "/familie/dokument/api/mapper/ping",
+            )
+            cors { configurationSource = corsConfigurationSource() }
+            csrf { disable() }
+            authorizeHttpRequests {
+                authorize(anyRequest, permitAll)
+            }
+        }
+        return http.build()
+    }
+
+    @Bean
+    @Order(2)
+    fun securedFilterChain(
         http: HttpSecurity,
         tokenXJwtDecoder: TokenXJwtDecoder,
     ): SecurityFilterChain {
@@ -36,11 +58,6 @@ class SecurityConfig(
             cors { configurationSource = corsConfigurationSource() }
             csrf { disable() }
             authorizeHttpRequests {
-                authorize("/internal/**", permitAll)
-                authorize("/api/html-til-pdf", permitAll)
-                authorize("/familie/dokument/api/html-til-pdf", permitAll)
-                authorize("/api/mapper/ping", permitAll)
-                authorize("/familie/dokument/api/mapper/ping", permitAll)
                 authorize(anyRequest, authenticated)
             }
             oauth2ResourceServer {

--- a/src/test/kotlin/no/nav/familie/dokument/config/SecurityConfigIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/dokument/config/SecurityConfigIntegrationTest.kt
@@ -70,6 +70,20 @@ class SecurityConfigIntegrationTest : OppslagSpringRunnerTest() {
     }
 
     @Test
+    fun `html-til-pdf er tilgjengelig med Azure AD token`() {
+        headers.setBearerAuth(token(issuerId = "azuread"))
+
+        val response =
+            restTemplate.exchange<String>(
+                localhost("/api/html-til-pdf"),
+                HttpMethod.POST,
+                HttpEntity("<html></html>", headers),
+            )
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+    }
+
+    @Test
     fun `beskyttet endepunkt returnerer 401 uten token`() {
         val response =
             restTemplate.exchange<String>(


### PR DESCRIPTION
Med åpne og beskyttede endepunkter i samme `SecurityFilterChain` er det ikke mulig å nå de åpne endepunktene hvis man sender med et ugyldig token, for eksempel et Azure AD token i dette tilfellet.

Løser problemet ved å splitte i to `SecurityFilterChain`, en for åpne endepunkter med `@Order(1)` og en for endepunkter beskyttet av TokenX, med en `TokenXJwtDecoder` og `@Order(2)`.